### PR TITLE
Fix 2nd illegitimate RivaTuner link

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Those are currently supported:
 
 ## 2. Performance Overlay
 
-This is a very simple application that requires [Rivatuner Statistics Server Download](https://www.rivatuner.org/)
+This is a very simple application that requires [Rivatuner Statistics Server Download](https://www.guru3d.com/files-details/rtss-rivatuner-statistics-server-download.html))
 and provides asthetics of SteamOS Performance Overlay.
 
 Uninstall MSI Afterburner and any other OSD software.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ There are 5 modes of presentation:
 
 ## 3. Power Control
 
-This is a very simple application that requires [Rivatuner Statistics Server Download](https://www.rivatuner.org/)
+This is a very simple application that requires [Rivatuner Statistics Server Download](https://www.guru3d.com/files-details/rtss-rivatuner-statistics-server-download.html)
 and provides an easily accessible controls.
 
 Uninstall MSI Afterburner and any other OSD software.


### PR DESCRIPTION
There were 2 links and I missed the second one in last commit.