### PR TITLE
Include new Steam+DPadUP binding in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ Of course you will have access to all described shortcuts.
 | STEAM + R2                 | Mouse Left Click       | Mouse Left Click       |                        | Mouse Left Click       |
 | STEAM + Left Pad Press     | Mouse Right Click      | Mouse Right Click      |                        | Mouse Right Click      |
 | STEAM + Right Pad Press    | Mouse Left Click       | Mouse Left Click       |                        | Mouse Left Click       |
+| Steam + Up Pad Press       | Ctrl + Alt + U         | Ctrl + Alt + U         |                        |                        |
 | Left Pad                   | Mouse Scroll           |                        |                        |                        |
 | Left Joystick              | Mouse Scroll           |                        |                        |                        |
 | Right Joystick             | Mouse Trackpad         |                        |                        |                        |
@@ -251,6 +252,20 @@ to make `SteamController.exe` the one mapping those.
    on Steam Deck (or `Manage Action Set` button).
 1. In a new window click `DELETE`.
 1. Now click `B` or `DONE`.
+
+### 4.4. Fullscreen Scaling Hotkey (Steam + Up Pad Press)
+
+Many games in Windows will crash when attempting to start in fullscreen.  To have a fullscreen experience on the Steam Deck, you can use this keybind in any fullscreen scaling application to provide a shortcut capable of toggling the scaling.
+
+Example of Scaling software: https://store.steampowered.com/app/993090/Lossless_Scaling/
+
+To configure the hotkey in Lossless Scaling:
+1. Launch Lossless Scaling
+1. Open "Settings"
+1. Select the "Scale hotkey"
+1. Press "Steam+DPad Up"
+1. Verify that the hotkey was set to "Ctrl + Alt + U"
+1. Close the settings dialog
 
 ## 5. Risks
 


### PR DESCRIPTION
Added keybind to table list.  Included instructions on how the binding can be used to set up a full screen scaling toggle.