### PR TITLE
Run Microsoft store apps in fullscreen (Shortcut)

### DIFF
--- a/SteamController/Devices/KeyboardController.cs
+++ b/SteamController/Devices/KeyboardController.cs
@@ -126,6 +126,15 @@ namespace SteamController.Devices
         {
             Safe(() => simulator.Keyboard.KeyPress(keyCodes));
         }
+        public void KeyPressDown(params VirtualKeyCode[] keyCodes)
+        {
+            Safe(() => simulator.Keyboard.KeyDown(keyCodes));
+        }
+
+        public void KeyPressUp(params VirtualKeyCode[] keyCodes)
+        {
+            Safe(() => simulator.Keyboard.KeyUp(keyCodes));
+        }
 
         public void KeyPress(VirtualKeyCode modifierKey, params VirtualKeyCode[] keyCodes)
         {

--- a/SteamController/Profiles/Default/ShortcutsProfile.cs
+++ b/SteamController/Profiles/Default/ShortcutsProfile.cs
@@ -59,7 +59,15 @@ namespace SteamController.Profiles.Default
                 return true;
             }
 
-            if (c.Steam.BtnMenu.Pressed())
+            if (c.Steam.BtnMenu.HoldOnce(HoldToSwitchProfile, ShortcutConsumed))
+            {
+                c.Keyboard.KeyPressDown(VirtualKeyCode.LWIN);
+                c.Keyboard.KeyPress(VirtualKeyCode.LSHIFT, VirtualKeyCode.RETURN);
+                c.Keyboard.KeyPressUp(VirtualKeyCode.LWIN);
+                return true;
+            }
+
+            else if (c.Steam.BtnMenu.Pressed())
             {
                 c.Keyboard.KeyPress(VirtualKeyCode.F11);
                 return true;

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -10,6 +10,7 @@
 | STEAM + 3 dots             | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  |
 | STEAM + Options            | WIN + TAB              | WIN + TAB              | WIN + TAB              | WIN + TAB              | WIN + TAB              |
 | STEAM + Menu               | F11                    | F11                    | F11                    | F11                    | F11                    |
+| STEAM + Menu (hold for 1s) | WIN + LSHIFT + ENTER   | WIN + LSHIFT + ENTER   | WIN + LSHIFT + ENTER   | WIN + LSHIFT + ENTER   | WIN + LSHIFT + ENTER   |
 | STEAM + A                  | RETURN                 | RETURN                 | RETURN                 |                        | RETURN                 |
 | STEAM + B (hold for 1s)    | ALT + F4               | ALT + F4               | ALT + F4               |                        | ALT + F4               |
 | STEAM + B (hold for 3s)    | Kill active process    | Kill active process    | Kill active process    |                        | Kill active process    |


### PR DESCRIPTION
for full screen to work in microsoft store applications, the condition is that the LWin must be held down, and then press LShift + Enter. 

If you do all 3 at once it does not work.

Since the original Steam + menu shortcut presses the F11, which is a fullscreen mode, it is added that holding it down for a full second will call the microsoft store app shortcut in fullscreen.