### PR TITLE
Attempted fix for joystick snapping to cardinal directions in gamepad mode

### DIFF
--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -52,10 +52,10 @@ namespace SteamController.Devices
         public readonly SteamAxis GyroYaw = new SteamAxis(0x22);
         public readonly SteamAxis LeftTrigger = new SteamAxis(0x2C);
         public readonly SteamAxis RightTrigger = new SteamAxis(0x2E);
-        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
         public readonly SteamAxis LPadPressure = new SteamAxis(0x38);
         public readonly SteamAxis RPadPressure = new SteamAxis(0x38);
 

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -52,10 +52,10 @@ namespace SteamController.Devices
         public readonly SteamAxis GyroYaw = new SteamAxis(0x22);
         public readonly SteamAxis LeftTrigger = new SteamAxis(0x2C);
         public readonly SteamAxis RightTrigger = new SteamAxis(0x2E);
-        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 0, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
         public readonly SteamAxis LPadPressure = new SteamAxis(0x38);
         public readonly SteamAxis RPadPressure = new SteamAxis(0x38);
 


### PR DESCRIPTION
- Ideal deadzone will need to be 0 to completely eliminate the snapping. The downside of this is that in desktop mode, there will be at least some amount of drift in the joysticks which will result in the mouse pointer drifting by itself or the scroll function automatically crawling a scrollable window. 

- Have set deadzone to 1400 from original 5000 as a balanced value. This will reduce the snapping to a negligibly small amount and will not exhibit drifting of mouse operations in desktop mode (provided the joystick hardware is functioning correctly). 