### PR TITLE
Silent Fan profile added (v2.0)

### DIFF
--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -10,6 +10,7 @@ namespace CommonHelpers
     public enum FanMode : uint
     {
         Default = 17374,
+        Silent,
         SteamOS,
         Max
     }

--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -6,6 +6,7 @@ namespace CommonHelpers
     {
         Default = 17374,
         Silent,
+        SemiSilent,
         SteamOS,
         Max
     }
@@ -56,9 +57,7 @@ namespace CommonHelpers
     [StructLayout(LayoutKind.Sequential)]
     public struct PowerControlSetting
     {
-        public PowerControlVisible Visible;
-        public string? CurrentTDP;
-        public string DesiredTDP;
+        public PowerControlVisible Current;
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 
 namespace CommonHelpers
 {
@@ -61,7 +56,9 @@ namespace CommonHelpers
     [StructLayout(LayoutKind.Sequential)]
     public struct PowerControlSetting
     {
-        public PowerControlVisible Current;
+        public PowerControlVisible Visible;
+        public string? CurrentTDP;
+        public string DesiredTDP;
     }
 
     [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Unicode)]

--- a/CommonHelpers/GlobalConstants.cs
+++ b/CommonHelpers/GlobalConstants.cs
@@ -1,8 +1,0 @@
-﻿namespace CommonHelpers
-{
-    public class GlobalConstants
-    {
-        public static string DefaultSilentTDP = "10W";
-        public static string DefaultSilentTDPChangeWarning = $"TDP reset to {DefaultSilentTDP}.";
-    }
-}

--- a/CommonHelpers/GlobalConstants.cs
+++ b/CommonHelpers/GlobalConstants.cs
@@ -1,0 +1,7 @@
+﻿namespace CommonHelpers
+{
+    public static class GlobalConstants
+    {
+        public static string DefaultSilentTDP = "10W";
+    }
+}

--- a/CommonHelpers/GlobalConstants.cs
+++ b/CommonHelpers/GlobalConstants.cs
@@ -1,7 +1,8 @@
 ﻿namespace CommonHelpers
 {
-    public static class GlobalConstants
+    public class GlobalConstants
     {
         public static string DefaultSilentTDP = "10W";
+        public static string DefaultSilentTDPChangeWarning = $"TDP reset to {DefaultSilentTDP}.";
     }
 }

--- a/CommonHelpers/Notifier.cs
+++ b/CommonHelpers/Notifier.cs
@@ -1,0 +1,23 @@
+﻿using System.ComponentModel;
+
+namespace CommonHelpers
+{
+    public class Notifier
+    {
+        public static void Notify(
+            string message,
+            string title,
+            Icon minorIcon,
+            ToolTipIcon majorIcon = ToolTipIcon.Info,
+            int timeout = 3000)
+        {
+            using (var container = new Container())
+            using (var notifyIcon = new NotifyIcon(container))
+            {
+                notifyIcon.Icon = minorIcon;
+                notifyIcon.Visible = true;
+                notifyIcon.ShowBalloonTip(timeout, title, message, majorIcon);
+            }
+        }
+    }
+}

--- a/CommonHelpers/SharedData.cs
+++ b/CommonHelpers/SharedData.cs
@@ -1,11 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.IO.MemoryMappedFiles;
-using System.Linq;
+﻿using System.IO.MemoryMappedFiles;
 using System.Runtime.InteropServices;
-using System.Runtime.Serialization.Formatters.Binary;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace CommonHelpers
 {

--- a/FanControl/FanControlForm.cs
+++ b/FanControl/FanControlForm.cs
@@ -11,8 +11,7 @@ namespace FanControl
             "Starts Steam Deck Fan Control on Windows startup."
         );
 
-        private SharedData<FanModeSetting> sharedFMSData = SharedData<FanModeSetting>.CreateNew();
-        private SharedData<PowerControlSetting> sharedPCSData = SharedData<PowerControlSetting>.CreateNew();
+        private SharedData<FanModeSetting> sharedData = SharedData<FanModeSetting>.CreateNew();
 
         public FanControlForm()
         {
@@ -132,9 +131,10 @@ namespace FanControl
             setFanMode(selectedFanMode);
             if (selectedFanMode == FanMode.Silent)
             {
-                sharedPCSData.GetValue(out var sharedPCS);
-                sharedPCS.DesiredTDP = GlobalConstants.DefaultSilentTDP;
-                sharedPCSData.SetValue(sharedPCS);
+                Notifier.Notify(
+                    GlobalConstants.DefaultSilentTDPChangeWarning,
+                    Text,
+                    Icon);
             }
         }
 
@@ -168,12 +168,12 @@ namespace FanControl
 
         private void SharedData_Update()
         {
-            if (sharedFMSData.GetValue(out var value) && Enum.IsDefined<FanMode>(value.Desired))
+            if (sharedData.GetValue(out var value) && Enum.IsDefined<FanMode>(value.Desired))
             {
                 setFanMode((FanMode)value.Desired);
             }
 
-            sharedFMSData.SetValue(new FanModeSetting()
+            sharedData.SetValue(new FanModeSetting()
             {
                 Current = fanControl.Mode,
                 KernelDriversLoaded = Instance.UseKernelDrivers ? KernelDriversLoaded.Yes : KernelDriversLoaded.No

--- a/FanControl/FanControlForm.cs
+++ b/FanControl/FanControlForm.cs
@@ -133,7 +133,7 @@ namespace FanControl
             if (selectedFanMode == FanMode.Silent)
             {
                 sharedPCSData.GetValue(out var sharedPCS);
-                sharedPCS.DesiredTDP = "10W";
+                sharedPCS.DesiredTDP = GlobalConstants.DefaultSilentTDP;
                 sharedPCSData.SetValue(sharedPCS);
             }
         }

--- a/FanControl/FanControlForm.cs
+++ b/FanControl/FanControlForm.cs
@@ -127,15 +127,7 @@ namespace FanControl
         private void fanModeSelectMenu_SelectedIndexChanged(object sender, EventArgs e)
         {
             var menuItem = (ToolStripComboBox)sender;
-            var selectedFanMode = (FanMode)menuItem.SelectedItem;
-            setFanMode(selectedFanMode);
-            if (selectedFanMode == FanMode.Silent)
-            {
-                Notifier.Notify(
-                    GlobalConstants.DefaultSilentTDPChangeWarning,
-                    Text,
-                    Icon);
-            }
+            setFanMode((FanMode)menuItem.SelectedItem);
         }
 
         private void FanControlForm_FormClosing(object sender, FormClosingEventArgs e)

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -1,11 +1,6 @@
 ﻿using CommonHelpers;
 using LibreHardwareMonitor.Hardware;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FanControl
 {

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -40,6 +40,13 @@ namespace FanControl
                                 MinRPM = 1500
                             }
                         },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinRPM = 1500
+                            }
+                        },
                     }
                 }
             },
@@ -64,7 +71,18 @@ namespace FanControl
                                 B = -188.6f,
                                 C = 5457.0f
                             }
-                        }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -89,7 +107,18 @@ namespace FanControl
                                 B = -188.6f,
                                 C = 5457.0f
                             }
-                        }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -104,6 +133,19 @@ namespace FanControl
                     {
                         {
                             FanMode.SteamOS, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Pid,
+                                MinInput = 30,
+                                MaxInput = 70,
+                                MaxRPM = 3000,
+                                PidSetPoint = 70,
+                                Kp = 0,
+                                Ki = -20,
+                                Kd = 0
+                            }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Pid,
                                 MinInput = 30,
@@ -129,6 +171,17 @@ namespace FanControl
                     {
                         {
                             FanMode.SteamOS, new FanSensor.Profile()
+                            {
+                                // If battery goes over 40oC require 2kRPM
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinInput = 0,
+                                MaxInput = 40,
+                                MinRPM = 0,
+                                MaxRPM = 2000,
+                            }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
                             {
                                 // If battery goes over 40oC require 2kRPM
                                 Type = FanSensor.Profile.ProfileType.Constant,

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -42,6 +42,13 @@ namespace FanControl
                                 MinRPM = 1500
                             }
                         },
+                        {
+                            FanMode.SemiSilent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinRPM = 1500
+                            }
+                        },
                     }
                 }
             },
@@ -78,6 +85,17 @@ namespace FanControl
                                 C = 3000f
                             }
                         },
+                        {
+                            FanMode.SemiSilent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -105,6 +123,17 @@ namespace FanControl
                         },
                         {
                             FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
+                        {
+                            FanMode.SemiSilent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Exponential,
                                 MinInput = 55,
@@ -151,7 +180,20 @@ namespace FanControl
                                 Ki = -20,
                                 Kd = 0
                             }
-                        }
+                        },
+                        {
+                            FanMode.SemiSilent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Pid,
+                                MinInput = 30,
+                                MaxInput = 70,
+                                MaxRPM = 3000,
+                                PidSetPoint = 70,
+                                Kp = 0,
+                                Ki = -20,
+                                Kd = 0
+                            }
+                        },
                     }
                 }
             },
@@ -185,7 +227,18 @@ namespace FanControl
                                 MinRPM = 0,
                                 MaxRPM = 2000,
                             }
-                        }
+                        },
+                        {
+                            FanMode.SemiSilent, new FanSensor.Profile()
+                            {
+                                // If battery goes over 40oC require 2kRPM
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinInput = 0,
+                                MaxInput = 40,
+                                MinRPM = 0,
+                                MaxRPM = 2000,
+                            }
+                        },
                     }
                 }
             }

--- a/FanControl/FanSensor.cs
+++ b/FanControl/FanSensor.cs
@@ -1,12 +1,6 @@
 ﻿using CommonHelpers;
 using LibreHardwareMonitor.Hardware;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Security.Policy;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FanControl
 {
@@ -36,7 +30,8 @@ namespace FanControl
             {
                 Constant,
                 Quadratic,
-                Pid
+                Pid,
+                Exponential
             }
 
             public ProfileType Type { get; set; }
@@ -78,6 +73,10 @@ namespace FanControl
                     case ProfileType.Pid:
                         rpm = calculatePidRPM(input);
                         break;
+
+                    case ProfileType.Exponential:
+                        rpm = calculateExponentialRPM(input);
+                        break;
                 }
 
                 if (input < MinInput)
@@ -118,6 +117,11 @@ namespace FanControl
                 pidLastTime = DateTime.Now;
 
                 return pidP + pidI + pidD;
+            }
+
+            private float calculateExponentialRPM(float input)
+            {
+                return (float)(Math.Pow(A, input - B) + C);
             }
         }
 

--- a/PerformanceOverlay/Controller.cs
+++ b/PerformanceOverlay/Controller.cs
@@ -270,7 +270,7 @@ namespace PerformanceOverlay
             // If Power Control is visible use temporarily full OSD
             if (Settings.Default.EnableFullOnPowerControl)
             {
-                if (SharedData<PowerControlSetting>.GetExistingValue(out var value) && value.Visible == PowerControlVisible.Yes)
+                if (SharedData<PowerControlSetting>.GetExistingValue(out var value) && value.Current == PowerControlVisible.Yes)
                     osdMode = OverlayMode.Full;
             }
 

--- a/PerformanceOverlay/Controller.cs
+++ b/PerformanceOverlay/Controller.cs
@@ -9,6 +9,9 @@ namespace PerformanceOverlay
     {
         public const String Title = "Performance Overlay";
         public static readonly String TitleWithVersion = Title + " v" + System.Windows.Forms.Application.ProductVersion.ToString();
+        public static readonly Icon Icon = WindowsDarkMode.IsDarkModeEnabled
+            ? Resources.poll_light
+            : Resources.poll;
 
         Container components = new Container();
         RTSSSharedMemoryNET.OSD? osd;
@@ -104,7 +107,7 @@ namespace PerformanceOverlay
             exitItem.Click += ExitItem_Click;
 
             notifyIcon = new System.Windows.Forms.NotifyIcon(components);
-            notifyIcon.Icon = WindowsDarkMode.IsDarkModeEnabled ? Resources.poll_light : Resources.poll;
+            notifyIcon.Icon = Icon;
             notifyIcon.Text = TitleWithVersion;
             notifyIcon.Visible = true;
             notifyIcon.ContextMenuStrip = contextMenu;
@@ -241,7 +244,7 @@ namespace PerformanceOverlay
             try
             {
                 notifyIcon.Text = TitleWithVersion + ". RTSS Version: " + OSD.Version;
-                notifyIcon.Icon = WindowsDarkMode.IsDarkModeEnabled ? Resources.poll_light : Resources.poll;
+                notifyIcon.Icon = Icon;
             }
             catch
             {
@@ -267,7 +270,7 @@ namespace PerformanceOverlay
             // If Power Control is visible use temporarily full OSD
             if (Settings.Default.EnableFullOnPowerControl)
             {
-                if (SharedData<PowerControlSetting>.GetExistingValue(out var value) && value.Current == PowerControlVisible.Yes)
+                if (SharedData<PowerControlSetting>.GetExistingValue(out var value) && value.Visible == PowerControlVisible.Yes)
                     osdMode = OverlayMode.Full;
             }
 

--- a/PowerControl/Controller.cs
+++ b/PowerControl/Controller.cs
@@ -34,7 +34,6 @@ namespace PowerControl
         SDCInput neptuneDeviceState = new SDCInput();
         DateTime? neptuneDeviceNextKey;
         System.Windows.Forms.Timer neptuneTimer;
-        System.Windows.Forms.Timer powerControlLoopTimer;
 
         ProfilesController? profilesController;
 
@@ -253,11 +252,6 @@ namespace PowerControl
 
             wasInternalDisplayConnected = ExternalHelpers.DisplayConfig.IsInternalConnected.GetValueOrDefault(false);
             SystemEvents.DisplaySettingsChanged += SystemEvents_DisplaySettingsChanged;
-
-            powerControlLoopTimer = new System.Windows.Forms.Timer(components);
-            powerControlLoopTimer.Enabled = true;
-            powerControlLoopTimer.Interval = 250;
-            powerControlLoopTimer.Tick += new EventHandler(PowerControlLoopTimer_Tick);
         }
 
         private void OsdTimer_Tick(object? sender, EventArgs e)
@@ -305,35 +299,6 @@ namespace PowerControl
                 Thread.Sleep(50);
 
             return new Task(() => { });
-        }
-
-        private void PowerControlLoopTimer_Tick(object sender, EventArgs e)
-        {
-            if (powerControlLoopTimer is null)
-                return;
-
-            try
-            {
-                powerControlLoopTimer.Enabled = false;
-
-                //if (TDP.Instance != null
-                //    && sharedData.GetValue(out var sharedPCS)
-                //    && TDP.Instance.Options.Contains(sharedPCS.DesiredTDP)
-                //    && TDP.Instance.ActiveOption != sharedPCS.DesiredTDP)
-                //{
-                //    TDP.Instance.Set(sharedPCS.DesiredTDP, false, true);
-                //    Notifier.Notify(
-                //        $"TDP reset to {TDP.DefaultSilentTDP}.",
-                //        TitleWithVersion,
-                //        Icon);
-                //    sharedPCS.CurrentTDP = sharedPCS.DesiredTDP;
-                //    sharedData.SetValue(sharedPCS);
-                //}
-            }
-            finally
-            {
-                powerControlLoopTimer.Enabled = true;
-            }
         }
 
         private void dismissNeptuneInput()
@@ -447,7 +412,7 @@ namespace PowerControl
         {
             sharedData.SetValue(new PowerControlSetting()
             {
-                Visible = rootMenu.Visible ? PowerControlVisible.Yes : PowerControlVisible.No
+                Current = rootMenu.Visible ? PowerControlVisible.Yes : PowerControlVisible.No
             });
 
             if (!rootMenu.Visible)

--- a/PowerControl/Options/CPUFrequency.cs
+++ b/PowerControl/Options/CPUFrequency.cs
@@ -7,22 +7,23 @@ namespace PowerControl.Options
     {
         public const string SoftMin = "SoftMin";
         public const string SoftMax = "SoftMax";
+        public const string Name = "CPUFrequency";
 
         public const int DefaultMin = 1400;
         public const int DefaultMax = 3500;
 
         public static PersistedOptions UserOptions()
         {
-            var options = new PersistedOptions("CPUFrequency");
+            var options = new PersistedOptions(Name);
 
             if (options.GetOptions().Count() == 0)
             {
                 options.SetOptions(new PersistedOptions.Option[]
                 {
-                    options.ForOption("Default").Set(SoftMin, DefaultMin).Set(SoftMax, DefaultMax),
-                    options.ForOption("Power-Save").Set(SoftMin, 1400).Set(SoftMax, 1800),
-                    options.ForOption("Balanced").Set(SoftMin, 2200).Set(SoftMax, 2800),
-                    options.ForOption("Max").Set(SoftMin, 3000).Set(SoftMax, 3500),
+                    options.ForOption("Default")    .Set(SoftMin, DefaultMin)   .Set(SoftMax, DefaultMax),
+                    options.ForOption("Power-Save") .Set(SoftMin, 1400)         .Set(SoftMax, 1800),
+                    options.ForOption("Balanced")   .Set(SoftMin, 2200)         .Set(SoftMax, 2800),
+                    options.ForOption("Max")        .Set(SoftMin, 3000)         .Set(SoftMax, 3500),
                 });
             }
 

--- a/PowerControl/Options/FanControl.cs
+++ b/PowerControl/Options/FanControl.cs
@@ -27,6 +27,14 @@ namespace PowerControl.Options
                 value.Desired = Enum.Parse<FanMode>(selected);
                 if (!SharedData<FanModeSetting>.SetExistingValue(value))
                     return null;
+                if (value.Desired == FanMode.Silent && TDP.Instance != null && TDP.Instance.Options.Contains(GlobalConstants.DefaultSilentTDP))
+                {
+                    TDP.Instance.Set(GlobalConstants.DefaultSilentTDP, false, true);
+                    Notifier.Notify(
+                        $"TDP reset to {GlobalConstants.DefaultSilentTDP}.",
+                        Controller.TitleWithVersion,
+                        Controller.Icon);
+                }
                 return selected;
             }
         };

--- a/PowerControl/Options/FanControl.cs
+++ b/PowerControl/Options/FanControl.cs
@@ -31,7 +31,7 @@ namespace PowerControl.Options
                 {
                     TDP.Instance.Set(GlobalConstants.DefaultSilentTDP, false, true);
                     Notifier.Notify(
-                        $"TDP reset to {GlobalConstants.DefaultSilentTDP}.",
+                        GlobalConstants.DefaultSilentTDPChangeWarning,
                         Controller.TitleWithVersion,
                         Controller.Icon);
                 }

--- a/PowerControl/Options/FanControl.cs
+++ b/PowerControl/Options/FanControl.cs
@@ -27,11 +27,16 @@ namespace PowerControl.Options
                 value.Desired = Enum.Parse<FanMode>(selected);
                 if (!SharedData<FanModeSetting>.SetExistingValue(value))
                     return null;
-                if (value.Desired == FanMode.Silent && TDP.Instance != null && TDP.Instance.Options.Contains(GlobalConstants.DefaultSilentTDP))
+                if (value.Desired == FanMode.Silent 
+                    && TDP.Instance != null 
+                    && !string.IsNullOrWhiteSpace(TDP.Instance.ActiveOption)
+                    && TDP.Instance.Options.Contains(TDP.MaxSilentTDP)
+                    && TDP.UserOptions().ForOption(TDP.Instance.ActiveOption) > TDP.UserOptions().ForOption(TDP.MaxSilentTDP))
                 {
-                    TDP.Instance.Set(GlobalConstants.DefaultSilentTDP, false, true);
+                    TDP.Instance.Set(TDP.MaxSilentTDP, false, true);
+                    
                     Notifier.Notify(
-                        GlobalConstants.DefaultSilentTDPChangeWarning,
+                        TDP.SwitchedToSilentWithTooHighTDPWarning,
                         Controller.TitleWithVersion,
                         Controller.Icon);
                 }

--- a/PowerControl/Options/TDP.cs
+++ b/PowerControl/Options/TDP.cs
@@ -8,7 +8,12 @@ namespace PowerControl.Options
     {
         public const string SlowTDP = "SlowTDP";
         public const string FastTDP = "FastTDP";
+        public const string Name = "TDP";
 
+        public const string SwitchedToSilentWithTooHighTDPWarning = $"TDP reset to {MaxSilentTDP}.";
+        public static string TDPIncreasedWhileSilentIsActiveWarning = $"Fan reset to {FanMode.SemiSilent}.";
+
+        public const string MaxSilentTDP = "10W";
         public const string ResetTDP = "15W";
 
         public const int DefaultSlowTDP = 15000;
@@ -16,25 +21,25 @@ namespace PowerControl.Options
 
         public static PersistedOptions UserOptions()
         {
-            var options = new PersistedOptions("TDP");
+            var options = new PersistedOptions(Name);
 
-            if (options.GetOptions().Count() == 0)
+            if (!options.GetOptions().Any())
             {
                 options.SetOptions(new PersistedOptions.Option[]
                 {
-                    options.ForOption("3W").Set(SlowTDP, 3000).Set(FastTDP, 3000),
-                    options.ForOption("4W").Set(SlowTDP, 4000).Set(FastTDP, 4000),
-                    options.ForOption("5W").Set(SlowTDP, 5000).Set(FastTDP, 5000),
-                    options.ForOption("6W").Set(SlowTDP, 6000).Set(FastTDP, 6000),
-                    options.ForOption("7W").Set(SlowTDP, 7000).Set(FastTDP, 7000),
-                    options.ForOption("8W").Set(SlowTDP, 8000).Set(FastTDP, 8000),
-                    options.ForOption("9W").Set(SlowTDP, 9000).Set(FastTDP, 9000),
-                    options.ForOption(GlobalConstants.DefaultSilentTDP).Set(SlowTDP, 10000).Set(FastTDP, 10000),
-                    options.ForOption("11W").Set(SlowTDP, 11000).Set(FastTDP, 11000),
-                    options.ForOption("12W").Set(SlowTDP, 12000).Set(FastTDP, 12000),
-                    options.ForOption("13W").Set(SlowTDP, 13000).Set(FastTDP, 13000),
-                    options.ForOption("14W").Set(SlowTDP, 14000).Set(FastTDP, 14000),
-                    options.ForOption(ResetTDP).Set(SlowTDP, 15000).Set(FastTDP, 15000),
+                    options.ForOption("3W")         .Set(SlowTDP, 3000) .Set(FastTDP, 3000),
+                    options.ForOption("4W")         .Set(SlowTDP, 4000) .Set(FastTDP, 4000),
+                    options.ForOption("5W")         .Set(SlowTDP, 5000) .Set(FastTDP, 5000),
+                    options.ForOption("6W")         .Set(SlowTDP, 6000) .Set(FastTDP, 6000),
+                    options.ForOption("7W")         .Set(SlowTDP, 7000) .Set(FastTDP, 7000),
+                    options.ForOption("8W")         .Set(SlowTDP, 8000) .Set(FastTDP, 8000),
+                    options.ForOption("9W")         .Set(SlowTDP, 9000) .Set(FastTDP, 9000),
+                    options.ForOption(MaxSilentTDP) .Set(SlowTDP, 10000).Set(FastTDP, 10000),
+                    options.ForOption("11W")        .Set(SlowTDP, 11000).Set(FastTDP, 11000),
+                    options.ForOption("12W")        .Set(SlowTDP, 12000).Set(FastTDP, 12000),
+                    options.ForOption("13W")        .Set(SlowTDP, 13000).Set(FastTDP, 13000),
+                    options.ForOption("14W")        .Set(SlowTDP, 14000).Set(FastTDP, 14000),
+                    options.ForOption(ResetTDP)     .Set(SlowTDP, 15000).Set(FastTDP, 15000),
                 });
             }
 
@@ -51,8 +56,19 @@ namespace PowerControl.Options
             ResetValue = () => { return ResetTDP; },
             CurrentValue = delegate ()
             {
-                if (SharedData<FanModeSetting>.GetExistingValue(out var value) && value.Current == FanMode.Silent)
-                    return GlobalConstants.DefaultSilentTDP;
+                if (SharedData<FanModeSetting>.GetExistingValue(out var value) 
+                    && value.Current == FanMode.Silent
+                    && Instance != null
+                    && !string.IsNullOrWhiteSpace(Instance.ActiveOption)
+                    && UserOptions().ForOption(Instance.ActiveOption) > UserOptions().ForOption(MaxSilentTDP))
+                {
+                    Notifier.Notify(
+                        SwitchedToSilentWithTooHighTDPWarning,
+                        Controller.TitleWithVersion,
+                        Controller.Icon);
+
+                    return MaxSilentTDP;
+                }
                 else if (Instance != null)
                     return Instance.ActiveOption;
                 else
@@ -75,10 +91,15 @@ namespace PowerControl.Options
 
                 if (SharedData<FanModeSetting>.GetExistingValue(out var fanMode) 
                     && fanMode.Current == FanMode.Silent
-                    && selected != GlobalConstants.DefaultSilentTDP)
+                    && selectedOption > UserOptions().ForOption(MaxSilentTDP))
                 {
                     fanMode.Desired = FanMode.SemiSilent;
                     SharedData<FanModeSetting>.SetExistingValue(fanMode);
+                    
+                    Notifier.Notify(
+                        TDPIncreasedWhileSilentIsActiveWarning,
+                        Controller.TitleWithVersion,
+                        Controller.Icon);
                 }
 
                 if (VangoghGPU.IsSupported)

--- a/PowerControl/PersistedOptions.cs
+++ b/PowerControl/PersistedOptions.cs
@@ -1,10 +1,12 @@
+using PowerControl.Options;
+
 namespace PowerControl
 {
     public class PersistedOptions : CommonHelpers.BaseSettings
     {
         public const string OptionsKey = "Options";
 
-        public PersistedOptions(string name) : base(name + "Options")
+        public PersistedOptions(string name) : base(name + OptionsKey)
         {
         }
 
@@ -34,6 +36,38 @@ namespace PowerControl
             {
                 // Get and do not persist value
                 return Options.Get(FullKey(setting), defaultValue, false);
+            }
+
+            public static bool operator <(Option a, Option b)
+            {
+                if (a.Options.SettingsKey == TDP.Name + OptionsKey && b.Options.SettingsKey == TDP.Name + OptionsKey)
+                {
+                    return a.Get(TDP.SlowTDP, TDP.DefaultSlowTDP) < b.Get(TDP.SlowTDP, TDP.DefaultSlowTDP)
+                        && a.Get(TDP.FastTDP, TDP.DefaultFastTDP) < b.Get(TDP.FastTDP, TDP.DefaultFastTDP);
+                }
+                else if (a.Options.SettingsKey == CPUFrequency.Name + OptionsKey && b.Options.SettingsKey == CPUFrequency.Name + OptionsKey)
+                {
+                    return a.Get(CPUFrequency.SoftMin, CPUFrequency.DefaultMin) < b.Get(CPUFrequency.SoftMin, CPUFrequency.DefaultMin)
+                        && a.Get(CPUFrequency.SoftMax, CPUFrequency.DefaultMax) < b.Get(CPUFrequency.SoftMax, CPUFrequency.DefaultMax);
+                }
+                else
+                    throw new NotSupportedException($"Operation \"<\" is not supported for operands of types \"{a.Options.SettingsKey}\" and \"{b.Options.SettingsKey}\".");
+            }
+
+            public static bool operator >(Option a, Option b)
+            {
+                if (a.Options.SettingsKey == TDP.Name + OptionsKey && b.Options.SettingsKey == TDP.Name + OptionsKey)
+                {
+                    return a.Get(TDP.SlowTDP, TDP.DefaultSlowTDP) > b.Get(TDP.SlowTDP, TDP.DefaultSlowTDP)
+                        && a.Get(TDP.FastTDP, TDP.DefaultFastTDP) > b.Get(TDP.FastTDP, TDP.DefaultFastTDP);
+                }
+                else if (a.Options.SettingsKey == CPUFrequency.Name + OptionsKey && b.Options.SettingsKey == CPUFrequency.Name + OptionsKey)
+                {
+                    return a.Get(CPUFrequency.SoftMin, CPUFrequency.DefaultMin) > b.Get(CPUFrequency.SoftMin, CPUFrequency.DefaultMin)
+                        && a.Get(CPUFrequency.SoftMax, CPUFrequency.DefaultMax) > b.Get(CPUFrequency.SoftMax, CPUFrequency.DefaultMax);
+                }
+                else
+                    throw new NotSupportedException($"Operation \">\" is not supported for operands of types \"{a.Options.SettingsKey}\" and \"{b.Options.SettingsKey}\".");
             }
         }
 

--- a/SteamController/Controller.cs
+++ b/SteamController/Controller.cs
@@ -2,14 +2,19 @@ using CommonHelpers;
 using ExternalHelpers;
 using Microsoft.Win32;
 using System.ComponentModel;
-using System.Diagnostics;
 
 namespace SteamController
 {
     internal class Controller : IDisposable
     {
-        public const String Title = "Steam Controller";
-        public static readonly String TitleWithVersion = Title + " v" + Application.ProductVersion.ToString();
+        public const string Title = "Steam Controller";
+        public static readonly string TitleWithVersion = Title + " v" + Application.ProductVersion.ToString();
+        public static readonly Icon IconController = WindowsDarkMode.IsDarkModeEnabled 
+            ? Resources.microsoft_xbox_controller_off_white 
+            : Resources.microsoft_xbox_controller_off;
+        public static readonly Icon IconMonitor = WindowsDarkMode.IsDarkModeEnabled
+            ? Resources.monitor_off_white
+            : Resources.monitor;
 
         public const int ControllerDelayAfterResumeMs = 1000;
 
@@ -77,7 +82,7 @@ namespace SteamController
                 startupManager.Startup = true;
 
             notifyIcon = new NotifyIcon(components);
-            notifyIcon.Icon = WindowsDarkMode.IsDarkModeEnabled ? Resources.microsoft_xbox_controller_off_white : Resources.microsoft_xbox_controller_off;
+            notifyIcon.Icon = IconController;
             notifyIcon.Text = TitleWithVersion;
             notifyIcon.Visible = true;
 
@@ -218,10 +223,7 @@ namespace SteamController
             if (!context.KeyboardMouseValid)
             {
                 notifyIcon.Text = TitleWithVersion + ". Cannot send input.";
-                if (WindowsDarkMode.IsDarkModeEnabled)
-                    notifyIcon.Icon = Resources.monitor_off_white;
-                else
-                    notifyIcon.Icon = Resources.monitor_off;
+                notifyIcon.Icon = IconMonitor;
             }
             else if (!context.X360.Valid || !context.DS4.Valid)
             {
@@ -236,10 +238,7 @@ namespace SteamController
             else
             {
                 notifyIcon.Text = TitleWithVersion + ". Disabled";
-                if (WindowsDarkMode.IsDarkModeEnabled)
-                    notifyIcon.Icon = Resources.microsoft_xbox_controller_off_white;
-                else
-                    notifyIcon.Icon = Resources.microsoft_xbox_controller_off;
+                notifyIcon.Icon = IconController;
             }
 
             notifyIcon.Text += String.Format(". Updates: {0}/s", context.UpdatesPerSec);


### PR DESCRIPTION
More upgrades to Silent Fan profile.
* SemiSilent Fan profile had been added. It's a copy of the Silent Fan profile that, unlike the Silent Fan profile, allows user to increase the TDP higher than 10W. The SemiSilent Fan profile serves two purposes: 
** firstly as a precausios measure, so that the user will have to manually and intentionally push the TDP (and so the temperature) to its extremum;
** and secondly as simply a notification that to keep the Deck indeed silent there is a Silent Fan profile (10W-, for kind of an "average user"), and the SemiSilent is for those who wants to find a balance by him-/herself (11W+, for kind of an "advanced user").
* Now if user switches to Silent Fan profile in Fan Control or Power Control, while the TDP is set to 11W or higher, the TDP will automatically be pushed down to 10W and the user will be notified.
* Now if user increases TDP to 11W or higher in Power Control, while the Fan profile is set to Silent, the Fan profile will automatically be switched to SemiSilent and the user will be notified.
* Also, 11W, 13W and 14W TDP values were returned back for precise TDP adjustments (for the same SemiSilent Fan profile, for example).