### PR TITLE
Changes around Dead Zone

### DIFF
--- a/SteamController/Devices/SteamAction.cs
+++ b/SteamController/Devices/SteamAction.cs
@@ -271,8 +271,10 @@ namespace SteamController.Devices
         public SteamButton? ActiveButton { get; internal set; }
         public SteamButton? VirtualLeft { get; internal set; }
         public SteamButton? VirtualRight { get; internal set; }
+
         public short Deadzone { get; internal set; }
-        public short MinChange { get; internal set; }
+        public bool UseDeadzoneSetting {get; internal set;} = false;
+        public short MinChange { get; internal set; } = 10;
         public DeltaValueMode DeltaValueMode { get; internal set; } = DeltaValueMode.Absolute;
         public SteamAxis? PartnerAxis { get; internal set; }
 
@@ -293,8 +295,9 @@ namespace SteamController.Devices
         public static implicit operator bool(SteamAxis button) => button.Active;
         public static implicit operator short(SteamAxis button)
         {
+            if (button.UseDeadzoneSetting)
+                button.Deadzone = Settings.Default.JoystickDeadZone;
             int pValue = button.PartnerAxis?.Value ?? button.Value;
-            // get circular deadzone reference
             int dzValue = pValue == button.Value ? button.Value : (int)Math.Sqrt(pValue * pValue + button.Value * button.Value);
             return dzValue > button.Deadzone ? button.Value : (short)0;
         }
@@ -316,8 +319,7 @@ namespace SteamController.Devices
             
             int value = 0;
             int pValue = PartnerAxis?.Value ?? Value;
-           
-            // get circular deadzone reference
+            if (UseDeadzoneSetting) Deadzone = Settings.Default.JoystickDeadZone;
             int dzValue = (int)Math.Sqrt(pValue * pValue + Value * Value);
 
             switch (mode)

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -71,6 +71,12 @@ namespace SteamController.Devices
             LeftThumbX.VirtualRight = BtnVirtualLeftThumbRight;
             LeftThumbY.VirtualLeft = BtnVirtualLeftThumbDown;
             LeftThumbY.VirtualRight = BtnVirtualLeftThumbUp;
+
+            // set partner axes for circle deadzone
+            LeftThumbX.PartnerAxis = LeftThumbY;
+            LeftThumbY.PartnerAxis = LeftThumbX;
+            RightThumbX.PartnerAxis = RightThumbY;
+            RightThumbY.PartnerAxis = RightThumbX;
         }
     }
 }

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -52,10 +52,10 @@ namespace SteamController.Devices
         public readonly SteamAxis GyroYaw = new SteamAxis(0x22);
         public readonly SteamAxis LeftTrigger = new SteamAxis(0x2C);
         public readonly SteamAxis RightTrigger = new SteamAxis(0x2E);
-        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
         public readonly SteamAxis LPadPressure = new SteamAxis(0x38);
         public readonly SteamAxis RPadPressure = new SteamAxis(0x38);
 

--- a/SteamController/Settings.cs
+++ b/SteamController/Settings.cs
@@ -41,6 +41,14 @@ namespace SteamController
             set { Set("DetectRTSSForeground", value); }
         }
 
+        [Browsable(true)]
+        [Description("Deadzone for left and right sticks. Enter a number between 0 and 32768. If this number is too small you may experience drift. 5000 or smaller is recommended.")]
+        public short JoystickDeadZone
+        {
+            get { return Get<short>("JoystickDeadZone", 5000); }
+            set { Set("JoystickDeadZone", value); }
+        }
+
         [Description("Create a debug log in Documents/SteamDeckTools/Logs.")]
         public bool EnableDebugLogging
         {
@@ -86,6 +94,8 @@ namespace SteamController
             get { return Get<SteamControllerConfigsMode>("SteamControllerConfigs", SteamControllerConfigsMode.Overwrite); }
             set { Set("SteamControllerConfigs", value); }
         }
+
+        
 
         public enum KeyboardStyles
         {


### PR DESCRIPTION
There are two commits in this pull request. The first commit just adds a circular deadzone detection for the left and right joysticks. It does this by creating a property called "PartnerAxis" for the SteamAxis class, and if that property is set it uses both values to decide whether to snap to 0. Alone, this guarantees no snap to cardinal directions.

The second commit creates a "JoystickDeadZone" setting in the settings menu that accepts any short. I set to 0, no dead zone. I had to add a property called "UseDeadzoneSetting" to make this work so that the triggers and pads don't use the same setting.