### PR TITLE
Better Deadzone fix

### DIFF
--- a/SteamController/Devices/SteamAction.cs
+++ b/SteamController/Devices/SteamAction.cs
@@ -276,8 +276,6 @@ namespace SteamController.Devices
         public bool UseDeadzoneSetting {get; internal set;} = false;
         public short MinChange { get; internal set; } = 10;
         public DeltaValueMode DeltaValueMode { get; internal set; } = DeltaValueMode.Absolute;
-        public SteamAxis? PartnerAxis { get; internal set; }
-
         public short Value
         {
             get { return ValueCanBeUsed ? rawValue : (short)0; }
@@ -295,11 +293,7 @@ namespace SteamController.Devices
         public static implicit operator bool(SteamAxis button) => button.Active;
         public static implicit operator short(SteamAxis button)
         {
-            if (button.UseDeadzoneSetting)
-                button.Deadzone = Settings.Default.JoystickDeadZone;
-            int pValue = button.PartnerAxis?.Value ?? button.Value;
-            int dzValue = pValue == button.Value ? button.Value : (int)Math.Sqrt(pValue * pValue + button.Value * button.Value);
-            return dzValue > button.Deadzone ? button.Value : (short)0;
+            return button.Value;
         }
 
         public bool Active
@@ -318,22 +312,13 @@ namespace SteamController.Devices
         {
             
             int value = 0;
-            int pValue = PartnerAxis?.Value ?? Value;
-            if (UseDeadzoneSetting) Deadzone = Settings.Default.JoystickDeadZone;
-            int dzValue = (int)Math.Sqrt(pValue * pValue + Value * Value);
-
             switch (mode)
             {
                 case DeltaValueMode.Absolute:
-                    if (Math.Abs(dzValue) < Deadzone)
-                        return 0.0;
                     value = Value;
                     break;
 
                 case DeltaValueMode.AbsoluteTime:
-
-                    if (Math.Abs(dzValue) < Deadzone)
-                        return 0.0;
                     value = (int)(Value * (Controller?.DeltaTime ?? 0.0));
                     break;
 

--- a/SteamController/Devices/SteamAction.cs
+++ b/SteamController/Devices/SteamAction.cs
@@ -271,9 +271,6 @@ namespace SteamController.Devices
         public SteamButton? ActiveButton { get; internal set; }
         public SteamButton? VirtualLeft { get; internal set; }
         public SteamButton? VirtualRight { get; internal set; }
-
-        public short Deadzone { get; internal set; }
-        public bool UseDeadzoneSetting {get; internal set;} = false;
         public short MinChange { get; internal set; } = 10;
         public DeltaValueMode DeltaValueMode { get; internal set; } = DeltaValueMode.Absolute;
         public short Value

--- a/SteamController/Devices/SteamAction.cs
+++ b/SteamController/Devices/SteamAction.cs
@@ -271,8 +271,10 @@ namespace SteamController.Devices
         public SteamButton? ActiveButton { get; internal set; }
         public SteamButton? VirtualLeft { get; internal set; }
         public SteamButton? VirtualRight { get; internal set; }
+
         public short Deadzone { get; internal set; }
-        public short MinChange { get; internal set; }
+        public bool UseDeadzoneSetting {get; internal set;} = false;
+        public short MinChange { get; internal set; } = 10;
         public DeltaValueMode DeltaValueMode { get; internal set; } = DeltaValueMode.Absolute;
         public SteamAxis? PartnerAxis { get; internal set; }
 
@@ -293,8 +295,9 @@ namespace SteamController.Devices
         public static implicit operator bool(SteamAxis button) => button.Active;
         public static implicit operator short(SteamAxis button)
         {
+            if (button.UseDeadzoneSetting)
+                button.Deadzone = Settings.Default.JoystickDeadZone;
             int pValue = button.PartnerAxis?.Value ?? button.Value;
-            // get circular deadzone reference
             int dzValue = pValue == button.Value ? button.Value : (int)Math.Sqrt(pValue * pValue + button.Value * button.Value);
             return dzValue > button.Deadzone ? button.Value : (short)0;
         }
@@ -316,8 +319,7 @@ namespace SteamController.Devices
             
             int value = 0;
             int pValue = PartnerAxis?.Value ?? Value;
-           
-            // get circular deadzone reference
+            if (UseDeadzoneSetting) Deadzone = Settings.Default.JoystickDeadZone;
             int dzValue = (int)Math.Sqrt(pValue * pValue + Value * Value);
 
             switch (mode)

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -52,10 +52,10 @@ namespace SteamController.Devices
         public readonly SteamAxis GyroYaw = new SteamAxis(0x22);
         public readonly SteamAxis LeftTrigger = new SteamAxis(0x2C);
         public readonly SteamAxis RightTrigger = new SteamAxis(0x2E);
-        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) {MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) {MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) {MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) {MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
         public readonly SteamAxis LPadPressure = new SteamAxis(0x38);
         public readonly SteamAxis RPadPressure = new SteamAxis(0x38);
 
@@ -71,12 +71,6 @@ namespace SteamController.Devices
             LeftThumbX.VirtualRight = BtnVirtualLeftThumbRight;
             LeftThumbY.VirtualLeft = BtnVirtualLeftThumbDown;
             LeftThumbY.VirtualRight = BtnVirtualLeftThumbUp;
-
-            // set partner axes for circle deadzone
-            LeftThumbX.PartnerAxis = LeftThumbY;
-            LeftThumbY.PartnerAxis = LeftThumbX;
-            RightThumbX.PartnerAxis = RightThumbY;
-            RightThumbY.PartnerAxis = RightThumbX;
         }
     }
 }

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -71,6 +71,12 @@ namespace SteamController.Devices
             LeftThumbX.VirtualRight = BtnVirtualLeftThumbRight;
             LeftThumbY.VirtualLeft = BtnVirtualLeftThumbDown;
             LeftThumbY.VirtualRight = BtnVirtualLeftThumbUp;
+
+            // set partner axes for circle deadzone
+            LeftThumbX.PartnerAxis = LeftThumbY;
+            LeftThumbY.PartnerAxis = LeftThumbX;
+            RightThumbX.PartnerAxis = RightThumbY;
+            RightThumbY.PartnerAxis = RightThumbX;
         }
     }
 }

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -52,10 +52,10 @@ namespace SteamController.Devices
         public readonly SteamAxis GyroYaw = new SteamAxis(0x22);
         public readonly SteamAxis LeftTrigger = new SteamAxis(0x2C);
         public readonly SteamAxis RightTrigger = new SteamAxis(0x2E);
-        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) {UseDeadzoneSetting = true, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
         public readonly SteamAxis LPadPressure = new SteamAxis(0x38);
         public readonly SteamAxis RPadPressure = new SteamAxis(0x38);
 

--- a/SteamController/Profiles/Default/GuideShortcutsProfile.cs
+++ b/SteamController/Profiles/Default/GuideShortcutsProfile.cs
@@ -129,10 +129,15 @@ namespace SteamController.Profiles.Default
         {
             if (c.Steam.RightThumbX || c.Steam.RightThumbY)
             {
-                c.Mouse.MoveBy(
-                    c.Steam.RightThumbX.DeltaValue * Context.JoystickToMouseSensitivity,
-                    -c.Steam.RightThumbY.DeltaValue * Context.JoystickToMouseSensitivity
-                );
+                //use hardwired dead zone of 5000 for desktop mode
+                double dzcheck = Math.Sqrt(c.Steam.RightThumbX.Value*c.Steam.RightThumbX.Value + c.Steam.RightThumbY.Value*c.Steam.RightThumbY.Value);
+                if (dzcheck > 5000) {
+                    c.Mouse.MoveBy(
+                        c.Steam.RightThumbX.DeltaValue * Context.JoystickToMouseSensitivity,
+                        -c.Steam.RightThumbY.DeltaValue * Context.JoystickToMouseSensitivity
+                    );
+                }
+                
             }
         }
 

--- a/SteamController/Profiles/Predefined/DS4Profile.cs
+++ b/SteamController/Profiles/Predefined/DS4Profile.cs
@@ -80,10 +80,13 @@ namespace SteamController.Profiles.Predefined
             context.DS4[DS4Controller.Triangle] = context.Steam.BtnY;
 
             // Sticks
-            context.DS4[DS4Controller.LeftThumbX] = context.Steam.LeftThumbX;
-            context.DS4[DS4Controller.LeftThumbY] = context.Steam.LeftThumbY;
-            context.DS4[DS4Controller.RightThumbX] = context.Steam.RightThumbX;
-            context.DS4[DS4Controller.RightThumbY] = context.Steam.RightThumbY;
+            double dzcheckR = Math.Sqrt(context.Steam.RightThumbX.Value*context.Steam.RightThumbX.Value + context.Steam.RightThumbY.Value*context.Steam.RightThumbY.Value);
+            double dzcheckL = Math.Sqrt(context.Steam.LeftThumbX.Value*context.Steam.LeftThumbX.Value + context.Steam.LeftThumbY.Value*context.Steam.LeftThumbY.Value);
+         
+            context.DS4[DS4Controller.LeftThumbX] = dzcheckL < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.LeftThumbX;
+            context.DS4[DS4Controller.LeftThumbY] = dzcheckL < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.LeftThumbY;
+            context.DS4[DS4Controller.RightThumbX] = dzcheckR < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.RightThumbX;
+            context.DS4[DS4Controller.RightThumbY] = dzcheckR < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.RightThumbY;
             context.DS4[DS4Controller.ThumbLeft] = context.Steam.BtnLeftStickPress;
             context.DS4[DS4Controller.ThumbRight] = context.Steam.BtnRightStickPress;
 

--- a/SteamController/Profiles/Predefined/DesktopProfile.cs
+++ b/SteamController/Profiles/Predefined/DesktopProfile.cs
@@ -66,16 +66,20 @@ namespace SteamController.Profiles.Predefined
 
         private void EmulateScrollOnLStick(Context c)
         {
-            if (c.Steam.LeftThumbX)
-            {
-                c.Mouse.HorizontalScroll(c.Steam.LeftThumbX.DeltaValue * Context.ThumbToWhellSensitivity);
-            }
-            if (c.Steam.LeftThumbY)
-            {
-                c.Mouse.VerticalScroll(c.Steam.LeftThumbY.DeltaValue * Context.ThumbToWhellSensitivity * (double)Settings.Default.ScrollDirection);
+             //use hardwired dead zone of 5000 for desktop mode
+            double dzcheck = Math.Sqrt(c.Steam.LeftThumbX.Value*c.Steam.LeftThumbX.Value + c.Steam.LeftThumbY.Value*c.Steam.LeftThumbY.Value);
+            if (dzcheck > 5000) {
+                if (c.Steam.LeftThumbX)
+                {
+                    c.Mouse.HorizontalScroll(c.Steam.LeftThumbX.DeltaValue * Context.ThumbToWhellSensitivity);
+                }
+                if (c.Steam.LeftThumbY)
+                {
+                    c.Mouse.VerticalScroll(c.Steam.LeftThumbY.DeltaValue * Context.ThumbToWhellSensitivity * (double)Settings.Default.ScrollDirection);
+                }
             }
         }
-
+ 
         private void EmulateDPadArrows(Context c)
         {
             c.Keyboard[VirtualKeyCode.LEFT] = c.Steam.BtnDpadLeft;

--- a/SteamController/Profiles/Predefined/X360Profile.cs
+++ b/SteamController/Profiles/Predefined/X360Profile.cs
@@ -88,10 +88,12 @@ namespace SteamController.Profiles.Predefined
             context.X360[Xbox360Button.Y] = context.Steam.BtnY;
 
             // Sticks
-            context.X360[Xbox360Axis.LeftThumbX] = context.Steam.LeftThumbX;
-            context.X360[Xbox360Axis.LeftThumbY] = context.Steam.LeftThumbY;
-            context.X360[Xbox360Axis.RightThumbX] = context.Steam.RightThumbX;
-            context.X360[Xbox360Axis.RightThumbY] = context.Steam.RightThumbY;
+            double dzcheckR = Math.Sqrt(context.Steam.RightThumbX.Value*context.Steam.RightThumbX.Value + context.Steam.RightThumbY.Value*context.Steam.RightThumbY.Value);
+            double dzcheckL = Math.Sqrt(context.Steam.LeftThumbX.Value*context.Steam.LeftThumbX.Value + context.Steam.LeftThumbY.Value*context.Steam.LeftThumbY.Value);
+            context.X360[Xbox360Axis.LeftThumbX] = dzcheckL < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.LeftThumbX;
+            context.X360[Xbox360Axis.LeftThumbY] = dzcheckL < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.LeftThumbY;
+            context.X360[Xbox360Axis.RightThumbX] = dzcheckR < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.RightThumbX;
+            context.X360[Xbox360Axis.RightThumbY] = dzcheckR < Settings.Default.JoystickDeadZone ? (short)0: context.Steam.RightThumbY;
             context.X360[Xbox360Button.LeftThumb] = context.Steam.BtnLeftStickPress;
             context.X360[Xbox360Button.RightThumb] = context.Steam.BtnRightStickPress;
 

--- a/SteamController/Settings.cs
+++ b/SteamController/Settings.cs
@@ -41,6 +41,14 @@ namespace SteamController
             set { Set("DetectRTSSForeground", value); }
         }
 
+        [Browsable(true)]
+        [Description("Deadzone for left and right sticks. Enter a number between 0 and 32768. If this number is too small you may experience drift. 5000 or smaller is recommended.")]
+        public short JoystickDeadZone
+        {
+            get { return Get<short>("JoystickDeadZone", 5000); }
+            set { Set("JoystickDeadZone", value); }
+        }
+
         [Description("Create a debug log in Documents/SteamDeckTools/Logs.")]
         public bool EnableDebugLogging
         {
@@ -86,6 +94,8 @@ namespace SteamController
             get { return Get<SteamControllerConfigsMode>("SteamControllerConfigs", SteamControllerConfigsMode.Overwrite); }
             set { Set("SteamControllerConfigs", value); }
         }
+
+        
 
         public enum KeyboardStyles
         {

--- a/SteamController/Settings.cs
+++ b/SteamController/Settings.cs
@@ -42,10 +42,10 @@ namespace SteamController
         }
 
         [Browsable(true)]
-        [Description("Deadzone for left and right sticks. Enter a number between 0 and 32768. If this number is too small you may experience drift. 5000 or smaller is recommended.")]
+        [Description("Deadzone for left and right sticks in X360 and DS4 mode. Enter a number between 0 and 32767. If this number is too small you may experience drift. 5000 or smaller is recommended, 3000 is default.")]
         public short JoystickDeadZone
         {
-            get { return Get<short>("JoystickDeadZone", 5000); }
+            get { return Get<short>("JoystickDeadZone", 3000); }
             set { Set("JoystickDeadZone", value); }
         }
 


### PR DESCRIPTION
Okay, after a few tries I think this is the best fix for deadzone entries. Deadzone is no longer dealt with at the device level - the device always returns the true value. Instead, deadzone is dealt with at the profile level in X360 and DS4 modes. I also added a setting so that value can be changed. In desktop mode the deadzone is still circular, but is fixed at a value of 5000.