### PR TITLE
Added Win+D shortcut

### DIFF
--- a/SteamController/Profiles/Default/GuideShortcutsProfile.cs
+++ b/SteamController/Profiles/Default/GuideShortcutsProfile.cs
@@ -91,19 +91,22 @@ namespace SteamController.Profiles.Default
 
             if (c.Steam.BtnDpadRight.Pressed())
             {
-                //c.Keyboard.KeyPress(VirtualKeyCode.RETURN); // old!
                 c.Keyboard.KeyPress(VirtualKeyCode.TAB);
             }
 
             if (c.Steam.BtnDpadDown.Pressed())
             {
-                //c.Keyboard.KeyPress(VirtualKeyCode.TAB);
-                c.Keyboard.KeyPress(VirtualKeyCode.LWIN,VirtualKeyCode.VK_D);
+                c.Keyboard.KeyPress(VirtualKeyCode.TAB);
             }
 
             if (c.Steam.BtnDpadLeft.Pressed())
             {
                 c.Keyboard.KeyPress(VirtualKeyCode.ESCAPE);
+            }
+
+            if (c.Steam.BtnRightStickPress.Pressed())
+            {
+                c.Keyboard.KeyPress(VirtualKeyCode.LWIN,VirtualKeyCode.VK_D);
             }
 
             // Additional binding for tool hotkeys (Lossless Fullscreen is nice)

--- a/SteamController/Profiles/Default/GuideShortcutsProfile.cs
+++ b/SteamController/Profiles/Default/GuideShortcutsProfile.cs
@@ -106,7 +106,7 @@ namespace SteamController.Profiles.Default
 
             if (c.Steam.BtnRightStickPress.Pressed())
             {
-                c.Keyboard.KeyPress(VirtualKeyCode.LWIN,VirtualKeyCode.VK_D);
+                c.Keyboard.KeyPress(VirtualKeyCode.LWIN, VirtualKeyCode.VK_D);
             }
 
             // Additional binding for tool hotkeys (Lossless Fullscreen is nice)

--- a/SteamController/Profiles/Default/GuideShortcutsProfile.cs
+++ b/SteamController/Profiles/Default/GuideShortcutsProfile.cs
@@ -91,12 +91,14 @@ namespace SteamController.Profiles.Default
 
             if (c.Steam.BtnDpadRight.Pressed())
             {
-                c.Keyboard.KeyPress(VirtualKeyCode.RETURN);
+                //c.Keyboard.KeyPress(VirtualKeyCode.RETURN); // old!
+                c.Keyboard.KeyPress(VirtualKeyCode.TAB);
             }
 
             if (c.Steam.BtnDpadDown.Pressed())
             {
-                c.Keyboard.KeyPress(VirtualKeyCode.TAB);
+                //c.Keyboard.KeyPress(VirtualKeyCode.TAB);
+                c.Keyboard.KeyPress(VirtualKeyCode.LWIN,VirtualKeyCode.VK_D);
             }
 
             if (c.Steam.BtnDpadLeft.Pressed())

--- a/SteamController/Profiles/Default/GuideShortcutsProfile.cs
+++ b/SteamController/Profiles/Default/GuideShortcutsProfile.cs
@@ -91,7 +91,7 @@ namespace SteamController.Profiles.Default
 
             if (c.Steam.BtnDpadRight.Pressed())
             {
-                c.Keyboard.KeyPress(VirtualKeyCode.TAB);
+                c.Keyboard.KeyPress(VirtualKeyCode.RETURN);
             }
 
             if (c.Steam.BtnDpadDown.Pressed())

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -10,6 +10,7 @@
 | STEAM + 3 dots             | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  | CTRL + SHIFT + ESCAPE  |
 | STEAM + Options            | WIN + TAB              | WIN + TAB              | WIN + TAB              | WIN + TAB              | WIN + TAB              |
 | STEAM + Menu               | F11                    | F11                    | F11                    | F11                    | F11                    |
+| STEAM + Right Stick Press  | WIN + D (Desktop)      | WIN + D (Desktop)      | WIN + D (Desktop)      |                        | WIN + D (Desktop)      |
 | STEAM + A                  | RETURN                 | RETURN                 | RETURN                 |                        | RETURN                 |
 | STEAM + B (hold for 1s)    | ALT + F4               | ALT + F4               | ALT + F4               |                        | ALT + F4               |
 | STEAM + B (hold for 3s)    | Kill active process    | Kill active process    | Kill active process    |                        | Kill active process    |
@@ -18,8 +19,8 @@
 | STEAM + R1                 | Screenshot             | Screenshot             | Screenshot             |                        | Screenshot             |
 | STEAM + Left Joystick Up   | Increase Brightness    | Increase Brightness    | Increase Brightness    |                        | Increase Brightness    |
 | STEAM + Left Joystick Down | Decrease Brightness    | Decrease Brightness    | Decrease Brightness    |                        | Decrease Brightness    |
-| STEAM + DPad Right         | TAB                    | TAB                    | TAB                    |                        | TAB                    |
-| STEAM + DPad Down          | WIN + D (Desktop)      | WIN + D (Desktop)      | WIN + D (Desktop)      |                        | WIN + D (Desktop)      |
+| STEAM + DPad Right         | RETURN                 | RETURN                 | RETURN                 |                        | RETURN                 |
+| STEAM + DPad Down          | TAB                    | TAB                    | TAB                    |                        | TAB                    |
 | STEAM + DPad Left          | ESCAPE                 | ESCAPE                 | ESCAPE                 |                        | ESCAPE                 |
 | STEAM + DPad Up            | CTRL + ALT + U         | CTRL + ALT + U         | CTRL + ALT + U         |                        | CTRL + ALT + U         |
 | STEAM + Left Pad           | Mouse Scroll           | Mouse Scroll           | Mouse Scroll           |                        | Mouse Scroll           |

--- a/docs/shortcuts.md
+++ b/docs/shortcuts.md
@@ -18,8 +18,8 @@
 | STEAM + R1                 | Screenshot             | Screenshot             | Screenshot             |                        | Screenshot             |
 | STEAM + Left Joystick Up   | Increase Brightness    | Increase Brightness    | Increase Brightness    |                        | Increase Brightness    |
 | STEAM + Left Joystick Down | Decrease Brightness    | Decrease Brightness    | Decrease Brightness    |                        | Decrease Brightness    |
-| STEAM + DPad Right         | RETURN                 | RETURN                 | RETURN                 |                        | RETURN                 |
-| STEAM + DPad Down          | TAB                    | TAB                    | TAB                    |                        | TAB                    |
+| STEAM + DPad Right         | TAB                    | TAB                    | TAB                    |                        | TAB                    |
+| STEAM + DPad Down          | WIN + D (Desktop)      | WIN + D (Desktop)      | WIN + D (Desktop)      |                        | WIN + D (Desktop)      |
 | STEAM + DPad Left          | ESCAPE                 | ESCAPE                 | ESCAPE                 |                        | ESCAPE                 |
 | STEAM + DPad Up            | CTRL + ALT + U         | CTRL + ALT + U         | CTRL + ALT + U         |                        | CTRL + ALT + U         |
 | STEAM + Left Pad           | Mouse Scroll           | Mouse Scroll           | Mouse Scroll           |                        | Mouse Scroll           |


### PR DESCRIPTION
**The comment below is now out of date, left here for posterity I guess**. This now simply adds one shortcut for win+d.

This change makes Steam+Right into TAB and Steam+DpadDown into Win+D, which shows the desktop (minimizing everything).  Also updates the documentation. Might also need to add a popup on install to let people know?

I think that Win+D is a very useful shortcut for most people and I don't think we need RETURN on two different shortcuts. 

If reluctant to accept this because of breaking changes for users who have gotten used to Steam+Right or Steam+Down as they are, I could also add a "use old shortcuts" setting for anybody who wants the old ones back.