### PR TITLE
Silent Fan profile added (v3.0)

### DIFF
--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 
 namespace CommonHelpers
 {

--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -10,6 +10,7 @@ namespace CommonHelpers
     public enum FanMode : uint
     {
         Default = 17374,
+        Silent,
         SteamOS,
         Max
     }

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -1,11 +1,6 @@
 ﻿using CommonHelpers;
 using LibreHardwareMonitor.Hardware;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FanControl
 {

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -40,6 +40,13 @@ namespace FanControl
                                 MinRPM = 1500
                             }
                         },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinRPM = 1500
+                            }
+                        },
                     }
                 }
             },
@@ -64,7 +71,18 @@ namespace FanControl
                                 B = -188.6f,
                                 C = 5457.0f
                             }
-                        }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -89,7 +107,18 @@ namespace FanControl
                                 B = -188.6f,
                                 C = 5457.0f
                             }
-                        }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -104,6 +133,19 @@ namespace FanControl
                     {
                         {
                             FanMode.SteamOS, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Pid,
+                                MinInput = 30,
+                                MaxInput = 70,
+                                MaxRPM = 3000,
+                                PidSetPoint = 70,
+                                Kp = 0,
+                                Ki = -20,
+                                Kd = 0
+                            }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Pid,
                                 MinInput = 30,
@@ -129,6 +171,17 @@ namespace FanControl
                     {
                         {
                             FanMode.SteamOS, new FanSensor.Profile()
+                            {
+                                // If battery goes over 40oC require 2kRPM
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinInput = 0,
+                                MaxInput = 40,
+                                MinRPM = 0,
+                                MaxRPM = 2000,
+                            }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
                             {
                                 // If battery goes over 40oC require 2kRPM
                                 Type = FanSensor.Profile.ProfileType.Constant,

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -71,10 +71,10 @@ namespace FanControl
                             FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Exponential,
-                                MinInput = 55,
-                                MaxInput = 93,
+                                MinInput = 40,
+                                MaxInput = 95,
                                 A = 1.28f,
-                                B = 60f,
+                                B = Settings.Default.Silent4000RPMThreshold - 28,
                                 C = 3000f
                             }
                         },
@@ -107,10 +107,10 @@ namespace FanControl
                             FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Exponential,
-                                MinInput = 55,
-                                MaxInput = 93,
+                                MinInput = 40,
+                                MaxInput = 95,
                                 A = 1.28f,
-                                B = 60f,
+                                B = Settings.Default.Silent4000RPMThreshold - 28,
                                 C = 3000f
                             }
                         },

--- a/FanControl/FanSensor.cs
+++ b/FanControl/FanSensor.cs
@@ -1,12 +1,6 @@
 ﻿using CommonHelpers;
 using LibreHardwareMonitor.Hardware;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Security.Policy;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FanControl
 {
@@ -36,7 +30,8 @@ namespace FanControl
             {
                 Constant,
                 Quadratic,
-                Pid
+                Pid,
+                Exponential
             }
 
             public ProfileType Type { get; set; }
@@ -78,6 +73,10 @@ namespace FanControl
                     case ProfileType.Pid:
                         rpm = calculatePidRPM(input);
                         break;
+
+                    case ProfileType.Exponential:
+                        rpm = calculateExponentialRPM(input);
+                        break;
                 }
 
                 if (input < MinInput)
@@ -118,6 +117,11 @@ namespace FanControl
                 pidLastTime = DateTime.Now;
 
                 return pidP + pidI + pidD;
+            }
+
+            private float calculateExponentialRPM(float input)
+            {
+                return (float)(Math.Pow(A, input - B) + C);
             }
         }
 

--- a/FanControl/Settings.cs
+++ b/FanControl/Settings.cs
@@ -23,6 +23,12 @@ namespace FanControl
             set { Set("AlwaysOnTop", value); }
         }
 
+        public int Silent4000RPMThreshold
+        {
+            get { return Get("Silent4000RPMThreshold", 85); }
+            set { Set("Silent4000RPMThreshold", Math.Min(Math.Max(80, value), 90)); }
+        }
+
         public bool EnableExperimentalFeatures
         {
             get { return Instance.IsDEBUG; }

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,10 @@
 
 ## #{GIT_TAG_NAME}
 
+- PerformanceOverlay/PowerControl: Add support for `AMD Radeon RX 670 Graphics`
+
+## 0.6.19
+
 - FanControl: Support `0xB030/0xA` device
 - SteamController: `DS4` backpanel and haptic settings are part of Release build
 - Updater: Remove `InstallationTime`


### PR DESCRIPTION
Option `Silent4000RPMThreshold` in FanControl.dll.ini now defines at what temperature Silent fan curve should reach 4000 RPM. Minimum -- 80, default -- 85, maximum -- 90.

More tests are welcomed of course, but according to my tests:
* in Baldur's Gate 3 with any heavy graphical settings
* with Silent4000RPMThreshold being set to default value (85)
* with Silent fan profile-curve activated 
* and TDP set to 15W

SoC's temperature stays at ~90°C, what pushes the fan up to 6450 RPM and leaves some headroom for sudden jumps (to ~95°C, never seen 100°C). In this scenarion noise level is high, but that's expected because of the 15W TDP level.

* If you think that's still too risky, we can drop the default Silent4000RPMThreshold value to 80.
* With Silent4000RPMThreshold kept at 85, the TDP limitation to 12W lowers temperatures by 5°C (average under stress from ~90°C to ~85°C, sudden jumps from ~95°C to ~90°C). Such change eliminates most of the noise heard in previous scenario (Silent4000RPMThreshold == 85, TDP == 15W).
* Lowering the TDP level to 10W eliminates the noise almost completely.