### PR TITLE
Silent Fan profile added (v3.0)

### DIFF
--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Runtime.InteropServices;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Runtime.InteropServices;
 
 namespace CommonHelpers
 {

--- a/CommonHelpers/GlobalConfig.cs
+++ b/CommonHelpers/GlobalConfig.cs
@@ -10,6 +10,7 @@ namespace CommonHelpers
     public enum FanMode : uint
     {
         Default = 17374,
+        Silent,
         SteamOS,
         Max
     }

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -1,11 +1,6 @@
 ﻿using CommonHelpers;
 using LibreHardwareMonitor.Hardware;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FanControl
 {
@@ -40,6 +35,13 @@ namespace FanControl
                                 MinRPM = 1500
                             }
                         },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinRPM = 1500
+                            }
+                        },
                     }
                 }
             },
@@ -64,7 +66,18 @@ namespace FanControl
                                 B = -188.6f,
                                 C = 5457.0f
                             }
-                        }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -89,7 +102,18 @@ namespace FanControl
                                 B = -188.6f,
                                 C = 5457.0f
                             }
-                        }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Exponential,
+                                MinInput = 55,
+                                MaxInput = 93,
+                                A = 1.28f,
+                                B = 60f,
+                                C = 3000f
+                            }
+                        },
                     }
                 }
             },
@@ -104,6 +128,19 @@ namespace FanControl
                     {
                         {
                             FanMode.SteamOS, new FanSensor.Profile()
+                            {
+                                Type = FanSensor.Profile.ProfileType.Pid,
+                                MinInput = 30,
+                                MaxInput = 70,
+                                MaxRPM = 3000,
+                                PidSetPoint = 70,
+                                Kp = 0,
+                                Ki = -20,
+                                Kd = 0
+                            }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Pid,
                                 MinInput = 30,
@@ -129,6 +166,17 @@ namespace FanControl
                     {
                         {
                             FanMode.SteamOS, new FanSensor.Profile()
+                            {
+                                // If battery goes over 40oC require 2kRPM
+                                Type = FanSensor.Profile.ProfileType.Constant,
+                                MinInput = 0,
+                                MaxInput = 40,
+                                MinRPM = 0,
+                                MaxRPM = 2000,
+                            }
+                        },
+                        {
+                            FanMode.Silent, new FanSensor.Profile()
                             {
                                 // If battery goes over 40oC require 2kRPM
                                 Type = FanSensor.Profile.ProfileType.Constant,

--- a/FanControl/FanControllerSensors.cs
+++ b/FanControl/FanControllerSensors.cs
@@ -71,10 +71,10 @@ namespace FanControl
                             FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Exponential,
-                                MinInput = 55,
-                                MaxInput = 93,
+                                MinInput = 40,
+                                MaxInput = 95,
                                 A = 1.28f,
-                                B = 60f,
+                                B = Settings.Default.Silent4000RPMThreshold - 28,
                                 C = 3000f
                             }
                         },
@@ -107,10 +107,10 @@ namespace FanControl
                             FanMode.Silent, new FanSensor.Profile()
                             {
                                 Type = FanSensor.Profile.ProfileType.Exponential,
-                                MinInput = 55,
-                                MaxInput = 93,
+                                MinInput = 40,
+                                MaxInput = 95,
                                 A = 1.28f,
-                                B = 60f,
+                                B = Settings.Default.Silent4000RPMThreshold - 28,
                                 C = 3000f
                             }
                         },

--- a/FanControl/FanSensor.cs
+++ b/FanControl/FanSensor.cs
@@ -1,12 +1,6 @@
 ﻿using CommonHelpers;
 using LibreHardwareMonitor.Hardware;
-using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Security.Policy;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace FanControl
 {
@@ -36,7 +30,8 @@ namespace FanControl
             {
                 Constant,
                 Quadratic,
-                Pid
+                Pid,
+                Exponential
             }
 
             public ProfileType Type { get; set; }
@@ -78,6 +73,10 @@ namespace FanControl
                     case ProfileType.Pid:
                         rpm = calculatePidRPM(input);
                         break;
+
+                    case ProfileType.Exponential:
+                        rpm = calculateExponentialRPM(input);
+                        break;
                 }
 
                 if (input < MinInput)
@@ -118,6 +117,11 @@ namespace FanControl
                 pidLastTime = DateTime.Now;
 
                 return pidP + pidI + pidD;
+            }
+
+            private float calculateExponentialRPM(float input)
+            {
+                return (float)(Math.Pow(A, input - B) + C);
             }
         }
 

--- a/FanControl/Settings.cs
+++ b/FanControl/Settings.cs
@@ -23,6 +23,12 @@ namespace FanControl
             set { Set("AlwaysOnTop", value); }
         }
 
+        public int Silent4000RPMThreshold
+        {
+            get { return Get("Silent4000RPMThreshold", 85); }
+            set { Set("Silent4000RPMThreshold", Math.Min(Math.Max(80, value), 90)); }
+        }
+
         public bool EnableExperimentalFeatures
         {
             get { return Instance.IsDEBUG; }

--- a/PowerControl/Helpers/ProfileSettings.cs
+++ b/PowerControl/Helpers/ProfileSettings.cs
@@ -26,10 +26,10 @@ namespace PowerControl.Helper
 
         public String ProfileName { get; }
 
-        public ProfileSettings(string profileName) : base("PersistentSettings")
+        public ProfileSettings(string prefix, string profileName) : base("PersistentSettings")
         {
             this.ProfileName = profileName;
-            this.ConfigFile = Path.Combine(UserProfilesPath, String.Format("PowerControl.Process.{0}.ini", profileName));
+            this.ConfigFile = Path.Combine(UserProfilesPath, String.Format("{0}.{1}.ini", prefix, profileName));
 
             this.SettingChanging += delegate { };
             this.SettingChanged += delegate { };

--- a/PowerControl/Menu/MenuItemWithOptions.cs
+++ b/PowerControl/Menu/MenuItemWithOptions.cs
@@ -155,8 +155,48 @@ namespace PowerControl.Menu
                     toolStripItem.DropDownItems.Add(item);
                 }
 
+                AddMenuItemsToModifyProfile(
+                    PowerControl.Options.Profiles.Controller?.AutostartProfileSettings,
+                    toolStripItem.DropDownItems
+                );
+
                 toolStripItem.Visible = Visible && Options.Count > 0;
             };
+        }
+
+        private void AddMenuItemsToModifyProfile(Helper.ProfileSettings? profileSettings, ToolStripItemCollection dropDownItems)
+        {
+            if (profileSettings is null || PersistentKey is null)
+                return;
+
+            dropDownItems.Add(new ToolStripSeparator());
+
+            var headingItem = new ToolStripMenuItem(profileSettings.ProfileName + ": ");
+            dropDownItems.Add(headingItem);
+
+            var persistedValue = profileSettings.GetValue(PersistentKey);
+
+            foreach (var option in Options)
+            {
+                var item = new ToolStripMenuItem("Set: " + option);
+                item.Checked = option == persistedValue;
+                item.Click += delegate { profileSettings.SetValue(PersistentKey, option); };
+                headingItem.DropDownItems.Add(item);
+            }
+
+            if (persistedValue is not null)
+            {
+                headingItem.Text += persistedValue;
+                headingItem.Checked = true;
+
+                headingItem.DropDownItems.Add(new ToolStripSeparator());
+                var unsetItem = headingItem.DropDownItems.Add("Unset");
+                unsetItem.Click += delegate { profileSettings.DeleteKey(PersistentKey); };
+            }
+            else
+            {
+                headingItem.Text += "Not set";
+            }
         }
 
         private void SelectIndex(int index)

--- a/PowerControl/Options/Profiles.cs
+++ b/PowerControl/Options/Profiles.cs
@@ -10,7 +10,7 @@ namespace PowerControl.Options
             ApplyDelay = 500,
             OptionsValues = delegate ()
             {
-                var currentProfileSettings = Controller?.CurrentProfileSettings;
+                var currentProfileSettings = Controller?.GameProfileSettings;
                 if (currentProfileSettings == null)
                     return null;
 
@@ -34,7 +34,7 @@ namespace PowerControl.Options
             CycleOptions = false,
             CurrentValue = delegate ()
             {
-                var currentProfileSettings = Controller?.CurrentProfileSettings;
+                var currentProfileSettings = Controller?.GameProfileSettings;
                 if (currentProfileSettings == null)
                     return null;
 
@@ -53,11 +53,11 @@ namespace PowerControl.Options
 
                     case "Create New":
                         Controller?.CreateProfile(false);
-                        return Controller?.CurrentProfileSettings?.ProfileName;
+                        return Controller?.GameProfileSettings?.ProfileName;
 
                     case "Save All":
                         Controller?.CreateProfile(true);
-                        return Controller?.CurrentProfileSettings?.ProfileName;
+                        return Controller?.GameProfileSettings?.ProfileName;
 
                     default:
                         return selected;

--- a/PowerControl/ProfilesController.cs
+++ b/PowerControl/ProfilesController.cs
@@ -31,14 +31,20 @@ namespace PowerControl
         public ProfileSettings? GameProfileSettings { get; private set; }
 
         public ProfileSettings? SessionProfileSettings { get; private set; }
+        public ProfileSettings AutostartProfileSettings { get; private set; }
 
         public ProfilesController()
         {
             PowerControl.Options.Profiles.Controller = this;
             MenuStack.Root.ValueChanged += Root_OnOptionValueChange;
 
+            AutostartProfileSettings = new ProfileSettings("PowerControl", "Autostart");
+
             timer.Start();
             timer.Tick += Timer_Tick;
+
+            ProfileChanged(null);
+            ApplyProfile(AutostartProfileSettings);
         }
 
         ~ProfilesController()
@@ -106,13 +112,13 @@ namespace PowerControl
         {
             Log.TraceLine("ProfilesController: New Process: {0}/{1}", processId, processName);
 
-            var profileSettings = new ProfileSettings(processName);
+            var profileSettings = new ProfileSettings("PowerControl.Process", processName);
             watchedProcesses.Add(processId, profileSettings);
 
             // Create memory only SessionProfileSettings
             if (SessionProfileSettings is null)
             {
-                SessionProfileSettings = new ProfileSettings("Session:" + processName) { UseConfigFile = false };
+                SessionProfileSettings = new ProfileSettings("PowerControl.Session", "Session." + processName) { UseConfigFile = false };
                 SaveProfile(SessionProfileSettings);
             }
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,7 @@
 
 ## 0.6.16
 
+- PowerControl: Show Game Profiles menu item
 - PowerControl: Improve handling of restoring DesktopProfile
 - All: Support [unofficial APU drivers](https://sourceforge.net/projects/amernimezone/files/Release%20Polaris-Vega-Navi/AMD%20SOC%20Driver%20Variant/) that present themselves as `AMD Radeon 670M`
 - PowerControl: Show Game Profiles menu item

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,7 @@
 
 ## 0.6.16
 
+- PowerControl: Improve handling of restoring DesktopProfile
 - All: Support [unofficial APU drivers](https://sourceforge.net/projects/amernimezone/files/Release%20Polaris-Vega-Navi/AMD%20SOC%20Driver%20Variant/) that present themselves as `AMD Radeon 670M`
 - PowerControl: Show Game Profiles menu item
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -31,6 +31,7 @@
 
 ## 0.6.16
 
+- PowerControl: Allow to set Autostart Profile Settings
 - PowerControl: Show Game Profiles menu item
 - PowerControl: Improve handling of restoring DesktopProfile
 - All: Support [unofficial APU drivers](https://sourceforge.net/projects/amernimezone/files/Release%20Polaris-Vega-Navi/AMD%20SOC%20Driver%20Variant/) that present themselves as `AMD Radeon 670M`

--- a/SteamController/Devices/SteamButtons.cs
+++ b/SteamController/Devices/SteamButtons.cs
@@ -52,10 +52,10 @@ namespace SteamController.Devices
         public readonly SteamAxis GyroYaw = new SteamAxis(0x22);
         public readonly SteamAxis LeftTrigger = new SteamAxis(0x2C);
         public readonly SteamAxis RightTrigger = new SteamAxis(0x2E);
-        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
-        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 5000, MinChange = 10, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbX = new SteamAxis(0x30) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis LeftThumbY = new SteamAxis(0x32) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbX = new SteamAxis(0x34) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
+        public readonly SteamAxis RightThumbY = new SteamAxis(0x36) { Deadzone = 1400, MinChange = 0, DeltaValueMode = Devices.DeltaValueMode.AbsoluteTime };
         public readonly SteamAxis LPadPressure = new SteamAxis(0x38);
         public readonly SteamAxis RPadPressure = new SteamAxis(0x38);
 


### PR DESCRIPTION
Option Silent4000RPMThreshold in FanControl.dll.ini now defines at what temperature Silent fan curve should reach 4000 RPM. Minimum -- 80, default -- 85, maximum -- 90.

More tests are welcomed of course, but according to my tests:

*    in Baldur's Gate 3 with any heavy graphical settings
*    with Silent4000RPMThreshold being set to default value (85)
*    with Silent fan profile-curve activated
*    and TDP set to 15W

SoC's temperature stays at ~90°C, what pushes the fan up to 6450 RPM and leaves some headroom for sudden jumps (to ~95°C, never seen 100°C). In this scenarion noise level is high, but that's expected because of the 15W TDP level.

*    If you think that's still too risky, we can drop the default Silent4000RPMThreshold value to 80.
*    With Silent4000RPMThreshold kept at 85, the TDP limitation to 12W lowers temperatures by 5°C (average under stress from ~90°C to ~85°C, sudden jumps from ~95°C to ~90°C). Such change eliminates most of the noise heard in previous scenario (Silent4000RPMThreshold == 85, TDP == 15W).
*    Lowering the TDP level to 10W eliminates the noise almost completely.

