### PR TITLE
Update Vlv0100.cs to allow Charge Limit supports Board Revision 6 SD LCDs

### DIFF
--- a/CommonHelpers/Vlv0100.cs
+++ b/CommonHelpers/Vlv0100.cs
@@ -43,7 +43,7 @@
 
         private static readonly DeviceVersion[] deviceVersions = {
             // Steam Deck - LCD version
-            new DeviceVersion() { Firmware = 0xB030, BoardID = 0x6, PDCS = 0 /* 0x2B */, BatteryTempLE = false },
+            new DeviceVersion() { Firmware = 0xB030, BoardID = 0x6, PDCS = 0 /* 0x2B */, BatteryTempLE = false, MaxBatteryCharge = true },
             new DeviceVersion() { Firmware = 0xB030, BoardID = 0xA, PDCS = 0 /* 0x2B */, BatteryTempLE = false, MaxBatteryCharge = true },
 
             // Steam Deck - OLED version


### PR DESCRIPTION
Fixed charge limit for SD LCD with board revision 6