### PR TITLE
Support OLED EC firmware 0x1100 and show the current charge limit

### DIFF
--- a/CommonHelpers/Vlv0100.cs
+++ b/CommonHelpers/Vlv0100.cs
@@ -48,7 +48,8 @@
 
             // Steam Deck - OLED version
             // new DeviceVersion() { Firmware = 0x1030, BoardID = 0x5, PDCS = 0 /* 0x2F */, BatteryTempLE = true },
-            new DeviceVersion() { Firmware = 0x1050, BoardID = 0x5, PDCS = 0 /* 0x2F */, BatteryTempLE = true, MaxBatteryCharge = true }
+            new DeviceVersion() { Firmware = 0x1050, BoardID = 0x5, PDCS = 0 /* 0x2F */, BatteryTempLE = true, MaxBatteryCharge = true },
+            new DeviceVersion() { Firmware = 0x1100, BoardID = 0x5, PDCS = 0 /* 0x2F */, BatteryTempLE = true, MaxBatteryCharge = true }
         };
 
         public static Vlv0100 Instance = new Vlv0100();

--- a/PowerControl/Options/BatteryChargeLimit.cs
+++ b/PowerControl/Options/BatteryChargeLimit.cs
@@ -10,6 +10,19 @@ namespace PowerControl.Options
             ApplyDelay = 1000,
             Options = { "70%", "80%", "90%", "100%" },
             ActiveOption = "?",
+            CurrentValue = delegate ()
+            {
+                using (var vlv0100 = new Vlv0100())
+                {
+                    if (!vlv0100.Open())
+                        return null;
+
+                    var value = vlv0100.GetMaxBatteryCharge();
+                    if (value is null)
+                        return null;
+                    return value.ToString() + "%";
+                }
+            },
             ApplyValue = (selected) =>
             {
                 var value = int.Parse(selected.ToString().TrimEnd('%'));


### PR DESCRIPTION
## Problem

On a Steam Deck OLED running current EC firmware, the Charge Limit menu is inert: it shows a placeholder, selecting a value does nothing, and the battery charges past the limit.

Two independent causes:

**1. The device isn't in `deviceVersions`.** My unit reports `PDFV = 0x1100`, `XBID = 0x05`. The table only has `0x1050 / 0x5` for OLED, so `SupportedDevice` is null and both `GetMaxBatteryCharge()` and `SetMaxBatteryCharge()` return early without doing anything.

**2. `BatteryChargeLimit` never reads the live value.** It defines only `ApplyValue` and hardcodes `ActiveOption = "?"`. Unlike `Brightness` and `RefreshRate`, it has no `CurrentValue` delegate, so `MenuItemWithOptions.Update()` has nothing to call. This is **not** model-specific - as far as I can tell no Steam Deck has ever displayed its actual charge limit in this menu; it only shows a value after you set one in that session, and reverts to `?` on restart.

## Evidence that the register is unchanged

Rather than assume the offset, I read the device's own ACPI DSDT via `GetSystemFirmwareTable` (no driver or elevation needed) and parsed the AML field definitions:

```
--- ALL fields in region XECB (base 0xFE700B00) ---
   +0x090 CRLO   width=8    phys=0xFE700B90
   +0x091 CRHI   width=8    phys=0xFE700B91
   ...
   +0x09F MCBL   width=8    phys=0xFE700B9F
   ...
   +0x0BC LONR   width=8    phys=0xFE700BBC
   +0x0BF LEPM   width=8    phys=0xFE700BBF
```

`MCBL` sits at `0xFE700B00 + 0x9F`, exactly where the existing constant points. The layout did not move between `0x1050` and `0x1100`, so adding the version is sufficient - no address changes are needed.

## Hardware verification

With the entry added, writing `MCBL` takes effect immediately and reversibly. Plugged in at 83%:

| `MCBL` | Charging | ChargeRate |
|---|---|---|
| 80 (baseline) | False | 0 mW |
| 90 (+13s) | **True** | 18,493 mW |
| 90 (+117s) | True | 17,775 mW |
| 80 (restored) | **False** | 0 mW |

Reported capacity rose 43,743 → 44,294 mWh while the limit was 90, and froze when it went back to 80. Before the change, the same battery charged from 16% to 87% straight through 80% without pausing.

Note the LED goes green when the cap is reached - that is "on AC, not charging", not a fault.

## Changes

- `CommonHelpers/Vlv0100.cs` - add `Firmware = 0x1100, BoardID = 0x5` **alongside** `0x1050` rather than replacing it, so existing devices are unaffected.
- `PowerControl/Options/BatteryChargeLimit.cs` - add a `CurrentValue` delegate following the existing `Brightness` / `RefreshRate` pattern.

## Testing

Built from this branch and running on the device:

- Steam Deck OLED (Valve "Galileo"), BIOS `F7G0114`, EC `PDFV 0x1100` / `XBID 0x05`
- Windows 11 Pro 26100, .NET SDK 6.0.428, `net6.0-windows`
- Charge Limit menu now both **sets** and **displays** the live value; verified against direct reads of `0xFE700B9F`
- `FanControl`, `PerformanceOverlay`, `SteamController` all still start and run normally with the rebuilt `CommonHelpers`

I only have an OLED unit on this firmware, so the LCD paths are unchanged-by-construction rather than tested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
